### PR TITLE
Spring Security

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ The server handling HTTP calls.
 
 `StartController` - Responsible for returning the whole React App.
 
+### exception/
+`LoginFailedException` - Exception thrown then the logging in of a user to the application fails.
+
 ### util
 `Logger` - Utility class containing static methods to write to error and event logs.
 
@@ -47,10 +50,13 @@ The server handling HTTP calls.
 ## service/
 `PersonService` - Service Class that handles business logic related to persons.
 
+`SpringDataJpaUserDetailsService` - Used by Spring Security AuthenticationManager for fetching user information when authenticating.
+
 ### exceptions/
-`LoginFailedException` - Exception thrown then the logging in of a user to the application fails.
 
 `UserCreationFailedException` - Exception thrown when the creation of a new user to the application fails.
+
+`UserNotFoundException` - Exception thrown when requesting a user which does not exist in the database.
 
 ## repository/
 `PersonRepository` - Repository responsible for accessing data related to a `PersonEntity`.
@@ -67,3 +73,5 @@ The server handling HTTP calls.
 
 `LoginRequestDTO` - DTO containing information about a login request.
 
+## config/
+`SecurityConfiguration`- Configuration for Spring security.

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,11 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-security</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,10 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/kth/iv1201/gohire/SecurityConfiguration.java
+++ b/src/main/java/kth/iv1201/gohire/SecurityConfiguration.java
@@ -8,10 +8,7 @@ import org.springframework.security.authentication.dao.DaoAuthenticationProvider
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.core.userdetails.User;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
-import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
 
@@ -23,19 +20,20 @@ import static jakarta.servlet.DispatcherType.FORWARD;
 @EnableMethodSecurity
 public class SecurityConfiguration {
 
+    /**
+     * Defines URLs accessible to all users, logged in or not.
+     */
+    final String[] whitelist = { "/built/**", "/main.css", "/login", "/", "/error", "/api/login",
+            "/api/who", "/api/createApplicant" };
+
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
                 .authorizeHttpRequests((authorize) -> authorize
                         .dispatcherTypeMatchers(FORWARD, ERROR).permitAll()
-                        .requestMatchers("/built/**").permitAll()
-                        .requestMatchers("/main.css").permitAll()
-                        .requestMatchers("/login").permitAll()
-                        .requestMatchers("/").permitAll()
-                        .requestMatchers("/error").permitAll()
-                        .requestMatchers("/api/login").permitAll()
+                        .requestMatchers(whitelist).permitAll()
                         .anyRequest().authenticated()
-                ).csrf(csrf -> csrf
+                ).csrf(csrf -> csrf // TODO unsafe
                         .ignoringRequestMatchers("/**") )
                 .securityContext((securityContext) -> securityContext
                         .securityContextRepository(new HttpSessionSecurityContextRepository())

--- a/src/main/java/kth/iv1201/gohire/SecurityConfiguration.java
+++ b/src/main/java/kth/iv1201/gohire/SecurityConfiguration.java
@@ -23,8 +23,7 @@ public class SecurityConfiguration {
     /**
      * Defines URLs accessible to all users, logged in or not.
      */
-    final String[] whitelist = { "/built/**", "/main.css", "/login", "/", "/error", "/api/login",
-            "/api/who", "/api/createApplicant" };
+    final String[] whitelist = { "^(?!/api/).+", "/api/login", "/api/who", "/api/createApplicant" };
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {

--- a/src/main/java/kth/iv1201/gohire/SecurityConfiguration.java
+++ b/src/main/java/kth/iv1201/gohire/SecurityConfiguration.java
@@ -27,16 +27,13 @@ public class SecurityConfiguration {
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
                 .authorizeHttpRequests((authorize) -> authorize
-                        .requestMatchers("/api/login").permitAll()
                         .dispatcherTypeMatchers(FORWARD, ERROR).permitAll()
                         .requestMatchers("/built/**").permitAll()
-                        .requestMatchers("/built/bundle.js").permitAll()
                         .requestMatchers("/main.css").permitAll()
                         .requestMatchers("/login").permitAll()
                         .requestMatchers("/").permitAll()
                         .requestMatchers("/error").permitAll()
-                        .requestMatchers("/api/secret").hasRole("recruiter")
-                        .requestMatchers("/api/who").permitAll()
+                        .requestMatchers("/api/login").permitAll()
                         .anyRequest().authenticated()
                 ).csrf(csrf -> csrf
                         .ignoringRequestMatchers("/**") )

--- a/src/main/java/kth/iv1201/gohire/SecurityConfiguration.java
+++ b/src/main/java/kth/iv1201/gohire/SecurityConfiguration.java
@@ -1,0 +1,59 @@
+package kth.iv1201.gohire;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.ProviderManager;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
+
+import static jakarta.servlet.DispatcherType.ERROR;
+import static jakarta.servlet.DispatcherType.FORWARD;
+
+@Configuration
+@EnableWebSecurity
+@EnableMethodSecurity
+public class SecurityConfiguration {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .authorizeHttpRequests((authorize) -> authorize
+                        .requestMatchers("/api/login").permitAll()
+                        .dispatcherTypeMatchers(FORWARD, ERROR).permitAll()
+                        .requestMatchers("/built/**").permitAll()
+                        .requestMatchers("/built/bundle.js").permitAll()
+                        .requestMatchers("/main.css").permitAll()
+                        .requestMatchers("/login").permitAll()
+                        .requestMatchers("/").permitAll()
+                        .requestMatchers("/error").permitAll()
+                        .requestMatchers("/api/secret").hasRole("recruiter")
+                        .requestMatchers("/api/who").permitAll()
+                        .anyRequest().authenticated()
+                ).csrf(csrf -> csrf
+                        .ignoringRequestMatchers("/**") )
+                .securityContext((securityContext) -> securityContext
+                        .securityContextRepository(new HttpSessionSecurityContextRepository())
+                );
+
+        return http.build();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(UserDetailsService userDetailsService) {
+        DaoAuthenticationProvider authenticationProvider = new DaoAuthenticationProvider();
+        authenticationProvider.setUserDetailsService(userDetailsService);
+
+        return new ProviderManager(authenticationProvider);
+    }
+
+
+}

--- a/src/main/java/kth/iv1201/gohire/config/SecurityConfiguration.java
+++ b/src/main/java/kth/iv1201/gohire/config/SecurityConfiguration.java
@@ -15,6 +15,9 @@ import org.springframework.security.web.context.HttpSessionSecurityContextReposi
 import static jakarta.servlet.DispatcherType.ERROR;
 import static jakarta.servlet.DispatcherType.FORWARD;
 
+/**
+ * Configuration for Spring security.
+ */
 @Configuration
 @EnableWebSecurity
 @EnableMethodSecurity
@@ -25,6 +28,12 @@ public class SecurityConfiguration {
      */
     final String[] whitelist = { "/api/login", "/api/who", "/api/createApplicant"};
 
+    /**
+     * Configures security filters, which URLs are open and authorization only
+     * @param http needed to configure websecurity
+     * @return security filter chain to use for securing requests.
+     * @throws Exception if SecurityFilterChain creation fails.
+     */
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
@@ -42,6 +51,11 @@ public class SecurityConfiguration {
         return http.build();
     }
 
+    /**
+     * Creates an <code>AuthenticationManager</code> which manages the authentication of a user
+     * @param userDetailsService <code>UserDetailsService</code> for specifying how to access users
+     * @return the <code>AuthenticationManager</code>
+     */
     @Bean
     public AuthenticationManager authenticationManager(UserDetailsService userDetailsService) {
         DaoAuthenticationProvider authenticationProvider = new DaoAuthenticationProvider();

--- a/src/main/java/kth/iv1201/gohire/config/SecurityConfiguration.java
+++ b/src/main/java/kth/iv1201/gohire/config/SecurityConfiguration.java
@@ -1,4 +1,4 @@
-package kth.iv1201.gohire;
+package kth.iv1201.gohire.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/kth/iv1201/gohire/config/SecurityConfiguration.java
+++ b/src/main/java/kth/iv1201/gohire/config/SecurityConfiguration.java
@@ -21,9 +21,9 @@ import static jakarta.servlet.DispatcherType.FORWARD;
 public class SecurityConfiguration {
 
     /**
-     * Defines URLs accessible to all users, logged in or not.
+     * Defines api URLs accessible to all users, logged in or not.
      */
-    final String[] whitelist = { "^(?!/api/).+", "/api/login", "/api/who", "/api/createApplicant" };
+    final String[] whitelist = { "/api/login", "/api/who", "/api/createApplicant"};
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -31,7 +31,8 @@ public class SecurityConfiguration {
                 .authorizeHttpRequests((authorize) -> authorize
                         .dispatcherTypeMatchers(FORWARD, ERROR).permitAll()
                         .requestMatchers(whitelist).permitAll()
-                        .anyRequest().authenticated()
+                        .requestMatchers("/api/**").authenticated()
+                        .anyRequest().permitAll()
                 ).csrf(csrf -> csrf // TODO unsafe
                         .ignoringRequestMatchers("/**") )
                 .securityContext((securityContext) -> securityContext

--- a/src/main/java/kth/iv1201/gohire/controller/PersonController.java
+++ b/src/main/java/kth/iv1201/gohire/controller/PersonController.java
@@ -11,14 +11,10 @@ import kth.iv1201.gohire.service.exception.UserCreationFailedException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.authentication.AuthenticationManager;
-import org.springframework.security.authentication.TestingAuthenticationToken;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.User;
 import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
-import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.*;
 
 /**
@@ -47,7 +43,6 @@ public class PersonController {
      * @throws LoginFailedException If the username and password do not match an existing user.
      * @return <code>LoggedInPersonDTO</code> representing the logged-in user
      */
-    @PreAuthorize("permitAll()")
     @PostMapping("/login")
     public LoggedInPersonDTO login(@RequestBody @Valid LoginRequestDTO loginRequest, HttpSession session)
             throws LoginFailedException {
@@ -82,7 +77,6 @@ public class PersonController {
         return personService.createApplicantAccount(createApplicantRequest);
     }
 
-    @PreAuthorize("permitAll()")
     @GetMapping("/who")
     public String notSecret() {
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();

--- a/src/main/java/kth/iv1201/gohire/controller/PersonController.java
+++ b/src/main/java/kth/iv1201/gohire/controller/PersonController.java
@@ -55,35 +55,19 @@ public class PersonController {
         LoggedInPersonDTO user = personService.login(loginRequest);
 
         Authentication authenticationRequest =
-                UsernamePasswordAuthenticationToken.unauthenticated(loginRequest.getUsername(), loginRequest.getPassword());
+                UsernamePasswordAuthenticationToken.unauthenticated(loginRequest.getUsername(),
+                                                                    loginRequest.getPassword());
         Authentication authenticationResponse =
                 this.authenticationManager.authenticate(authenticationRequest);
-        System.out.println(authenticationResponse.getName());
-        System.out.println(authenticationResponse.isAuthenticated());
 
         if(authenticationResponse.isAuthenticated()) {
             SecurityContextHolder.getContext().setAuthentication(authenticationResponse);
-            // setting role to the session
             session.setAttribute(HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY,
                     SecurityContextHolder.getContext());
             return user;
         }
         else
-            return null;
-
-        /*Authentication authentication = authenticationManager
-                .authenticate(new UsernamePasswordAuthenticationToken(loginRequest.getUsername(), loginRequest.getPassword()));
-        SecurityContextHolder.getContext().setAuthentication(authentication);
-
-        User user2 = (User)SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-        String name = user2.getUsername();
-        System.out.println(name);
-
-        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-        System.out.println(auth.getName());
-
-        System.out.printf("%s logged in with role %s\n", user.getUsername(), user.getRole());
-        return user;*/
+            throw new LoginFailedException("Person with given credentials does not exist");
     }
 
     /**
@@ -106,8 +90,14 @@ public class PersonController {
     }
 
     @PreAuthorize("hasRole('recruiter')")
-    @GetMapping("/secret")
-    public String getSecret() {
+    @GetMapping("/recruiter")
+    public String getRecruiterSecret() {
+        return "Secret thing";
+    }
+
+    @PreAuthorize("hasRole('applicant')")
+    @GetMapping("/applicant")
+    public String getApplicantSecret() {
         return "Secret thing";
     }
 

--- a/src/main/java/kth/iv1201/gohire/controller/PersonController.java
+++ b/src/main/java/kth/iv1201/gohire/controller/PersonController.java
@@ -96,6 +96,8 @@ public class PersonController {
                         loginRequest.getPassword());
         Authentication authenticationResponse =
                 this.authenticationManager.authenticate(authenticationRequest);
+        System.out.println(authenticationResponse.getCredentials());
+        System.out.println(authenticationRequest.isAuthenticated());
         if(!authenticationRequest.isAuthenticated())
             throw new LoginFailedException("Person with given credentials does not exist.");
         return authenticationResponse;

--- a/src/main/java/kth/iv1201/gohire/controller/PersonController.java
+++ b/src/main/java/kth/iv1201/gohire/controller/PersonController.java
@@ -96,9 +96,7 @@ public class PersonController {
                         loginRequest.getPassword());
         Authentication authenticationResponse =
                 this.authenticationManager.authenticate(authenticationRequest);
-        System.out.println(authenticationResponse.getCredentials());
-        System.out.println(authenticationRequest.isAuthenticated());
-        if(!authenticationRequest.isAuthenticated())
+        if(!authenticationResponse.isAuthenticated())
             throw new LoginFailedException("Person with given credentials does not exist.");
         return authenticationResponse;
     }

--- a/src/main/java/kth/iv1201/gohire/controller/PersonController.java
+++ b/src/main/java/kth/iv1201/gohire/controller/PersonController.java
@@ -8,8 +8,9 @@ import kth.iv1201.gohire.DTO.LoginRequestDTO;
 import kth.iv1201.gohire.controller.util.Logger;
 import kth.iv1201.gohire.controller.util.LoggerException;
 import kth.iv1201.gohire.service.PersonService;
-import kth.iv1201.gohire.service.exception.LoginFailedException;
+import kth.iv1201.gohire.controller.exception.LoginFailedException;
 import kth.iv1201.gohire.service.exception.UserCreationFailedException;
+import kth.iv1201.gohire.service.exception.UserNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -44,29 +45,16 @@ public class PersonController {
      * @param loginRequest DTO containing login request data
      * @throws LoginFailedException If the username and password do not match an existing user.
      * @throws LoggerException if there is a problem with logging an event.
+     * @throws UserNotFoundException If the user is authenticated but can not be fetched from the database.
      * @return <code>LoggedInPersonDTO</code> representing the logged-in user
      */
     @PostMapping("/login")
     public LoggedInPersonDTO login(@RequestBody @Valid LoginRequestDTO loginRequest, HttpSession session)
-            throws LoginFailedException, LoggerException {
-
-        LoggedInPersonDTO user = personService.login(loginRequest);
-
-        Authentication authenticationRequest =
-                UsernamePasswordAuthenticationToken.unauthenticated(loginRequest.getUsername(),
-                                                                    loginRequest.getPassword());
-        Authentication authenticationResponse =
-                this.authenticationManager.authenticate(authenticationRequest);
-
-        if(authenticationResponse.isAuthenticated()) {
-            SecurityContextHolder.getContext().setAuthentication(authenticationResponse);
-            session.setAttribute(HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY,
-                    SecurityContextHolder.getContext());
-            Logger.logEvent("User logged in: " + user.getUsername());
-            return user;
-        }
-        else
-            throw new LoginFailedException("Person with given credentials does not exist");
+            throws LoggerException, UserNotFoundException, LoginFailedException {
+        Authentication authenticationResponse = authenticateLoginRequest(loginRequest);
+        saveAuthenticedUserInSession(authenticationResponse, session);
+        Logger.logEvent("User logged in: " + loginRequest.getUsername());
+        return personService.fetchLoggedInPersonByUsername(loginRequest.getUsername());
     }
 
     /**
@@ -100,6 +88,23 @@ public class PersonController {
     @GetMapping("/applicant")
     public String getApplicantSecret() {
         return "Secret thing";
+    }
+
+    private Authentication authenticateLoginRequest(LoginRequestDTO loginRequest) throws LoginFailedException {
+        Authentication authenticationRequest =
+                UsernamePasswordAuthenticationToken.unauthenticated(loginRequest.getUsername(),
+                        loginRequest.getPassword());
+        Authentication authenticationResponse =
+                this.authenticationManager.authenticate(authenticationRequest);
+        if(!authenticationRequest.isAuthenticated())
+            throw new LoginFailedException("Person with given credentials does not exist.");
+        return authenticationResponse;
+    }
+
+    private void saveAuthenticedUserInSession(Authentication authenticationResponse, HttpSession session) {
+        SecurityContextHolder.getContext().setAuthentication(authenticationResponse);
+        session.setAttribute(HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY,
+                SecurityContextHolder.getContext());
     }
 
 }

--- a/src/main/java/kth/iv1201/gohire/controller/PersonController.java
+++ b/src/main/java/kth/iv1201/gohire/controller/PersonController.java
@@ -52,7 +52,7 @@ public class PersonController {
     public LoggedInPersonDTO login(@RequestBody @Valid LoginRequestDTO loginRequest, HttpSession session)
             throws LoggerException, UserNotFoundException, LoginFailedException {
         Authentication authenticationResponse = authenticateLoginRequest(loginRequest);
-        saveAuthenticedUserInSession(authenticationResponse, session);
+        saveAuthenticatedUserInSession(authenticationResponse, session);
         Logger.logEvent("User logged in: " + loginRequest.getUsername());
         return personService.fetchLoggedInPersonByUsername(loginRequest.getUsername());
     }

--- a/src/main/java/kth/iv1201/gohire/controller/PersonController.java
+++ b/src/main/java/kth/iv1201/gohire/controller/PersonController.java
@@ -1,5 +1,6 @@
 package kth.iv1201.gohire.controller;
 
+import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import kth.iv1201.gohire.DTO.CreateApplicantRequestDTO;
 import kth.iv1201.gohire.DTO.LoggedInPersonDTO;
@@ -8,6 +9,15 @@ import kth.iv1201.gohire.service.PersonService;
 import kth.iv1201.gohire.service.exception.LoginFailedException;
 import kth.iv1201.gohire.service.exception.UserCreationFailedException;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.*;
 
@@ -19,27 +29,61 @@ import org.springframework.web.bind.annotation.*;
 public class PersonController {
 
     private final PersonService personService;
+    private final AuthenticationManager authenticationManager;
 
     /**
      * Creates a new <code>PersonController</code>
      * @param personService The <code>PersonService</code> to use
      */
     @Autowired
-    public PersonController(PersonService personService) {
+    public PersonController(PersonService personService, AuthenticationManager authenticationManager) {
         this.personService = personService;
+        this.authenticationManager = authenticationManager;
     }
 
     /**
      * Handles the login API-request
      * @param loginRequest DTO containing login request data
      * @throws LoginFailedException If the username and password do not match an existing user.
-     * @throws MethodArgumentNotValidException if any data does not match expected values.
      * @return <code>LoggedInPersonDTO</code> representing the logged-in user
      */
+    @PreAuthorize("permitAll()")
     @PostMapping("/login")
-    public LoggedInPersonDTO login(@RequestBody @Valid LoginRequestDTO loginRequest)
+    public LoggedInPersonDTO login(@RequestBody @Valid LoginRequestDTO loginRequest, HttpSession session)
             throws LoginFailedException {
-        return personService.login(loginRequest);
+
+        LoggedInPersonDTO user = personService.login(loginRequest);
+
+        Authentication authenticationRequest =
+                UsernamePasswordAuthenticationToken.unauthenticated(loginRequest.getUsername(), loginRequest.getPassword());
+        Authentication authenticationResponse =
+                this.authenticationManager.authenticate(authenticationRequest);
+        System.out.println(authenticationResponse.getName());
+        System.out.println(authenticationResponse.isAuthenticated());
+
+        if(authenticationResponse.isAuthenticated()) {
+            SecurityContextHolder.getContext().setAuthentication(authenticationResponse);
+            // setting role to the session
+            session.setAttribute(HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY,
+                    SecurityContextHolder.getContext());
+            return user;
+        }
+        else
+            return null;
+
+        /*Authentication authentication = authenticationManager
+                .authenticate(new UsernamePasswordAuthenticationToken(loginRequest.getUsername(), loginRequest.getPassword()));
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        User user2 = (User)SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        String name = user2.getUsername();
+        System.out.println(name);
+
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        System.out.println(auth.getName());
+
+        System.out.printf("%s logged in with role %s\n", user.getUsername(), user.getRole());
+        return user;*/
     }
 
     /**
@@ -47,11 +91,24 @@ public class PersonController {
      * @param createApplicantRequest DTO containing applicant request data.
      * @return <code>LoggedInPersonDTO</code> representing the newly created and logged-in user
      * @throws UserCreationFailedException If the requested username already exists.
-     * @throws MethodArgumentNotValidException if any data does not match expected values.
      */
     @PostMapping("/createApplicant")
     public LoggedInPersonDTO createNewApplicant(@RequestBody @Valid CreateApplicantRequestDTO createApplicantRequest)
             throws UserCreationFailedException {
         return personService.createApplicantAccount(createApplicantRequest);
     }
+
+    @PreAuthorize("permitAll()")
+    @GetMapping("/who")
+    public String notSecret() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        return auth.getName();
+    }
+
+    @PreAuthorize("hasRole('recruiter')")
+    @GetMapping("/secret")
+    public String getSecret() {
+        return "Secret thing";
+    }
+
 }

--- a/src/main/java/kth/iv1201/gohire/controller/PersonController.java
+++ b/src/main/java/kth/iv1201/gohire/controller/PersonController.java
@@ -103,7 +103,7 @@ public class PersonController {
         return authenticationResponse;
     }
 
-    private void saveAuthenticedUserInSession(Authentication authenticationResponse, HttpSession session) {
+    private void saveAuthenticatedUserInSession(Authentication authenticationResponse, HttpSession session) {
         SecurityContextHolder.getContext().setAuthentication(authenticationResponse);
         session.setAttribute(HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY,
                 SecurityContextHolder.getContext());

--- a/src/main/java/kth/iv1201/gohire/controller/PersonController.java
+++ b/src/main/java/kth/iv1201/gohire/controller/PersonController.java
@@ -78,6 +78,8 @@ public class PersonController {
         return auth.getName();
     }
 
+    /* The following methods are for testing purposes since there is no other protected content */
+
     @PreAuthorize("hasRole('recruiter')")
     @GetMapping("/recruiter")
     public String getRecruiterSecret() {

--- a/src/main/java/kth/iv1201/gohire/controller/exception/LoginFailedException.java
+++ b/src/main/java/kth/iv1201/gohire/controller/exception/LoginFailedException.java
@@ -1,4 +1,4 @@
-package kth.iv1201.gohire.service.exception;
+package kth.iv1201.gohire.controller.exception;
 
 /**
  * Exception thrown when the logging in of a user to the application fails.

--- a/src/main/java/kth/iv1201/gohire/repository/PersonRepository.java
+++ b/src/main/java/kth/iv1201/gohire/repository/PersonRepository.java
@@ -12,8 +12,6 @@ import org.springframework.transaction.annotation.Transactional;
 @Repository
 @Transactional(propagation = Propagation.MANDATORY)
 public interface PersonRepository extends JpaRepository<PersonEntity, Integer> {
-    PersonEntity findByUsernameAndPassword(String username, String password);
     PersonEntity findByUsername(String username);
-
     boolean existsByUsername(String username);
 }

--- a/src/main/java/kth/iv1201/gohire/repository/PersonRepository.java
+++ b/src/main/java/kth/iv1201/gohire/repository/PersonRepository.java
@@ -13,6 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(propagation = Propagation.MANDATORY)
 public interface PersonRepository extends JpaRepository<PersonEntity, Integer> {
     PersonEntity findByUsernameAndPassword(String username, String password);
+    PersonEntity findByUsername(String username);
 
     boolean existsByUsername(String username);
 }

--- a/src/main/java/kth/iv1201/gohire/service/PersonService.java
+++ b/src/main/java/kth/iv1201/gohire/service/PersonService.java
@@ -2,13 +2,12 @@ package kth.iv1201.gohire.service;
 
 import kth.iv1201.gohire.DTO.CreateApplicantRequestDTO;
 import kth.iv1201.gohire.DTO.LoggedInPersonDTO;
-import kth.iv1201.gohire.DTO.LoginRequestDTO;
 import kth.iv1201.gohire.entity.PersonEntity;
 import kth.iv1201.gohire.entity.RoleEntity;
 import kth.iv1201.gohire.repository.RoleRepository;
-import kth.iv1201.gohire.service.exception.LoginFailedException;
 import kth.iv1201.gohire.repository.PersonRepository;
 import kth.iv1201.gohire.service.exception.UserCreationFailedException;
+import kth.iv1201.gohire.service.exception.UserNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
@@ -32,17 +31,18 @@ public class PersonService {
     }
 
     /**
-     * Fetches a <code>LoggedInPersonDTO</code> matching the credentials entered by the user.
-     * @param loginRequest DTO containing the username and password entered by the user.
-     * @return <code>LoggedInPersonDTO</code> representing the logged-in user matching the entered credentials.
-     * @throws LoginFailedException when a matching user does not exist in the database.
+     * Fetches a user as a <code>LoggedInPersonDTO</code> by username
+     * @param username the username
+     * @return The <code>LoggedInPersonDTO</code>
+     * @throws UserNotFoundException Thrown if no user with that name is found
      */
-    public LoggedInPersonDTO login(LoginRequestDTO loginRequest) throws LoginFailedException {
-        PersonEntity personEntity = personRepository.findByUsernameAndPassword(loginRequest.getUsername(), loginRequest.getPassword());
+    public LoggedInPersonDTO fetchLoggedInPersonByUsername(String username) throws UserNotFoundException {
+        PersonEntity personEntity = personRepository.findByUsername(username);
         if(personEntity == null){
-            throw new LoginFailedException("Person with given credentials does not exist");
+            throw new UserNotFoundException("User with given username does not exist.");
         }
         return new LoggedInPersonDTO(personEntity.getId(), personEntity.getUsername(), personEntity.getRole().getName());
+
     }
 
     /**

--- a/src/main/java/kth/iv1201/gohire/service/SpringDataJpaUserDetailsService.java
+++ b/src/main/java/kth/iv1201/gohire/service/SpringDataJpaUserDetailsService.java
@@ -3,7 +3,6 @@ package kth.iv1201.gohire.service;
 import kth.iv1201.gohire.entity.PersonEntity;
 import kth.iv1201.gohire.repository.PersonRepository;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.core.authority.AuthorityUtils;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;

--- a/src/main/java/kth/iv1201/gohire/service/SpringDataJpaUserDetailsService.java
+++ b/src/main/java/kth/iv1201/gohire/service/SpringDataJpaUserDetailsService.java
@@ -11,17 +11,30 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
+/**
+ * Used by AuthenticationManager for fetching user information when authenticating.
+ */
 @Component
 @Transactional(rollbackFor = Exception.class, propagation = Propagation.REQUIRES_NEW)
 public class SpringDataJpaUserDetailsService implements UserDetailsService {
 
     private final PersonRepository repository;
 
+    /**
+     * Creates a new instance
+     * @param repository the personRepository for fetching users.
+     */
     @Autowired
     public SpringDataJpaUserDetailsService(PersonRepository repository) {
         this.repository = repository;
     }
 
+    /**
+     * Tells spring how to find a user
+     * @param name name of user
+     * @return User details
+     * @throws UsernameNotFoundException is thrown when fetching a user that does not exist.
+     */
     @Override
     public UserDetails loadUserByUsername(String name) throws UsernameNotFoundException {
         PersonEntity person = this.repository.findByUsername(name);
@@ -31,5 +44,4 @@ public class SpringDataJpaUserDetailsService implements UserDetailsService {
                 .roles(person.getRole().getName())
                 .build();
     }
-
 }

--- a/src/main/java/kth/iv1201/gohire/service/SpringDataJpaUserDetailsService.java
+++ b/src/main/java/kth/iv1201/gohire/service/SpringDataJpaUserDetailsService.java
@@ -1,0 +1,36 @@
+package kth.iv1201.gohire.service;
+
+import kth.iv1201.gohire.entity.PersonEntity;
+import kth.iv1201.gohire.repository.PersonRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@Transactional(rollbackFor = Exception.class, propagation = Propagation.REQUIRES_NEW)
+public class SpringDataJpaUserDetailsService implements UserDetailsService {
+
+    private final PersonRepository repository;
+
+    @Autowired
+    public SpringDataJpaUserDetailsService(PersonRepository repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String name) throws UsernameNotFoundException {
+        PersonEntity person = this.repository.findByUsername(name);
+        return User.withDefaultPasswordEncoder()
+                .username(person.getUsername())
+                .password(person.getPassword())
+                .roles(person.getRole().getName())
+                .build();
+    }
+
+}

--- a/src/main/java/kth/iv1201/gohire/service/exception/UserNotFoundException.java
+++ b/src/main/java/kth/iv1201/gohire/service/exception/UserNotFoundException.java
@@ -1,0 +1,13 @@
+package kth.iv1201.gohire.service.exception;
+
+/**
+ * Exception thrown when requesting a user which does not exist in the database.
+ */
+public class UserNotFoundException extends Exception{
+
+    /**
+     * Creates an instance of a throwable <code>UserNotFoundException</code>.
+     * @param message Exception message
+     */
+    public UserNotFoundException(String message) {super(message);}
+}

--- a/src/test/java/kth/iv1201/gohire/config/SecurityConfigurationTest.java
+++ b/src/test/java/kth/iv1201/gohire/config/SecurityConfigurationTest.java
@@ -1,0 +1,83 @@
+package kth.iv1201.gohire.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kth.iv1201.gohire.DTO.CreateApplicantRequestDTO;
+import kth.iv1201.gohire.DTO.LoginRequestDTO;
+import kth.iv1201.gohire.controller.PersonController;
+import kth.iv1201.gohire.service.PersonService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithAnonymousUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@AutoConfigureMockMvc
+class SecurityConfigurationTest {
+
+    @MockBean
+    PersonController personController;
+    @MockBean
+    PersonService personService;
+
+    LoginRequestDTO mockLoginRequestDTO;
+    CreateApplicantRequestDTO mockCreateApplicantRequestDTO;
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        mockLoginRequestDTO = new LoginRequestDTO("exampleUsername", "examplePassword");
+        mockCreateApplicantRequestDTO = new CreateApplicantRequestDTO("exampleFirstName", "exampleLastName", "example@example.com", "00123456-7890", "exampleUsername", "examplePassword");
+    }
+
+    @AfterEach
+    void tearDown() {
+        mockLoginRequestDTO = null;
+        mockCreateApplicantRequestDTO = null;
+    }
+
+    @Test
+    @WithAnonymousUser
+    void testIfNotLoggedInUserCanAccessLogin() {
+        assertDoesNotThrow(() -> {
+            mockMvc.perform(post("/api/login")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(mockLoginRequestDTO)))
+                    .andExpect(status().isOk());
+        }, "Non-logged in user could not access login.");
+    }
+
+    @Test
+    @WithAnonymousUser
+    void testIfNotLoggedInUserCanAccessCreateApplicant() {
+        assertDoesNotThrow(() -> {
+            mockMvc.perform(post("/api/createApplicant")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(mockCreateApplicantRequestDTO)))
+                    .andExpect(status().isOk());
+        }, "Non-logged in user could not access create applicant.");
+    }
+
+    @Test
+    @WithAnonymousUser
+    void testIfNotLoggedInUserCanAccessHtml() {
+        assertDoesNotThrow(() -> {
+            mockMvc.perform(get("/")).andExpect(status().isOk());
+        }, "Non-logged in user could not access HTML.");
+    }
+
+}

--- a/src/test/java/kth/iv1201/gohire/controller/PersonControllerTest.java
+++ b/src/test/java/kth/iv1201/gohire/controller/PersonControllerTest.java
@@ -20,13 +20,10 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
 @AutoConfigureMockMvc
@@ -46,9 +43,6 @@ class PersonControllerTest {
     UsernamePasswordAuthenticationToken mockAuthenticatedSuccessfulResponse;
     UsernamePasswordAuthenticationToken mockAuthenticatedFailedResponse;
     UsernamePasswordAuthenticationToken mockAuthenticationRequest;
-
-    @Autowired
-    private MockMvc mockMvc;
 
     @BeforeEach
     void setUp() {
@@ -101,24 +95,5 @@ class PersonControllerTest {
         LoggedInPersonDTO user = personController.createNewApplicant(mockCreateApplicantRequestDTO);
         assertEquals(mockCreateApplicantRequestDTO.getUsername(), user.getUsername(),"Returned LoggedInPersonDTO" +
                 "from PersonController does not equal returned LoggedInPersonDTO from PersonService.");
-    }
-
-    /* The following two tests are temporary since there is no other protected content */
-
-    @Test
-    @WithMockUser(roles = {"applicant"})
-    void testThatApplicantCanNotAccessRecruiterSecret() {
-        assertDoesNotThrow(() -> {
-            mockMvc.perform(get("/api/recruiter")).andExpect(status().isForbidden());
-        }, "Applicant was allowed to access recruiter secret.");
-    }
-
-    @Test
-    @WithMockUser(roles = {"recruiter"})
-    void testThatRecruiterCanAccessRecruiterSecret() {
-        assertDoesNotThrow(() -> {
-            mockMvc.perform(get("/api/recruiter")).andExpect(status().isOk());
-        }, "Recruiter was not allowed to access recruiter secret.");
-
     }
 }

--- a/src/test/java/kth/iv1201/gohire/controller/PersonControllerTest.java
+++ b/src/test/java/kth/iv1201/gohire/controller/PersonControllerTest.java
@@ -15,15 +15,21 @@ import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@SpringBootTest
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@AutoConfigureMockMvc
 class PersonControllerTest {
 
     @Mock
@@ -40,6 +46,9 @@ class PersonControllerTest {
     UsernamePasswordAuthenticationToken mockAuthenticatedSuccessfulResponse;
     UsernamePasswordAuthenticationToken mockAuthenticatedFailedResponse;
     UsernamePasswordAuthenticationToken mockAuthenticationRequest;
+
+    @Autowired
+    private MockMvc mockMvc;
 
     @BeforeEach
     void setUp() {
@@ -80,19 +89,20 @@ class PersonControllerTest {
     }
 
     @Test
-    void testIfMethodArgumentNotValidExceptionIsThrownWhenCredentialsAreNull(){
+    void testIfMethodArgumentNotValidExceptionIsThrownWhenLoginCredentialsAreNull(){
         // TODO
     }
 
     @Test
-    void testIfCorrectExceptionThrownWhenCredentialsAreBlank(){
+    void testIfCorrectExceptionThrownWhenLoginCredentialsAreBlank(){
         // TODO
     }
 
     @Test
-    void testIfExceptionThrownWhenCredentialsAreGreaterThenMax(){
+    void testIfExceptionThrownWhenLoginCredentialsAreGreaterThenMax(){
         // TODO
     }
+
     @Test
     void testIfApplicantCreationFailedExceptionIsThrownWhenUsernameAlreadyExistsInDB() throws UserCreationFailedException {
         when(personService.createApplicantAccount(mockCreateApplicantRequestDTO)).thenThrow(new UserCreationFailedException("Username already exists in database"));
@@ -169,6 +179,25 @@ class PersonControllerTest {
 
     @Test
     void testCreateApplicanIfExceptionIsThrownIfPasswordIsTooLong() {
+
+    }
+
+    /* The following two tests are temporary since there is no other protected content */
+
+    @Test
+    @WithMockUser(roles = {"applicant"})
+    void testThatApplicantCanNotAccessRecruiterSecret() {
+        assertDoesNotThrow(() -> {
+            mockMvc.perform(get("/api/recruiter")).andExpect(status().isForbidden());
+        }, "Applicant was allowed to access recruiter secret.");
+    }
+
+    @Test
+    @WithMockUser(roles = {"recruiter"})
+    void testThatRecruiterCanAccessRecruiterSecret() {
+        assertDoesNotThrow(() -> {
+            mockMvc.perform(get("/api/recruiter")).andExpect(status().isOk());
+        }, "Recruiter was not allowed to access recruiter secret.");
 
     }
 }

--- a/src/test/java/kth/iv1201/gohire/controller/PersonControllerTest.java
+++ b/src/test/java/kth/iv1201/gohire/controller/PersonControllerTest.java
@@ -16,16 +16,11 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.security.authentication.AuthenticationManager;
-import org.springframework.security.authentication.TestingAuthenticationToken;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
-
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @SpringBootTest
@@ -42,8 +37,8 @@ class PersonControllerTest {
     LoginRequestDTO mockLoginRequestDTO;
     LoggedInPersonDTO mockLoggedInPersonDTO;
     CreateApplicantRequestDTO mockCreateApplicantRequestDTO;
-    TestingAuthenticationToken mockAuthenticatedSuccessfulResponse;
-    TestingAuthenticationToken mockAuthenticatedFailedResponse;
+    UsernamePasswordAuthenticationToken mockAuthenticatedSuccessfulResponse;
+    UsernamePasswordAuthenticationToken mockAuthenticatedFailedResponse;
     UsernamePasswordAuthenticationToken mockAuthenticationRequest;
 
     @BeforeEach
@@ -52,11 +47,9 @@ class PersonControllerTest {
         mockLoginRequestDTO = new LoginRequestDTO("exampleUsername", "examplePassword");
         mockLoggedInPersonDTO = new LoggedInPersonDTO(0, "exampleUsername", "recruiter");
         mockCreateApplicantRequestDTO = new CreateApplicantRequestDTO("exampleFirstName", "exampleLastName", "example@example.com", "123456-7890", "exampleUsername", "examplePassword");
-        mockAuthenticatedSuccessfulResponse = new TestingAuthenticationToken("exampleUsername2", "examplePassword2");
-        mockAuthenticatedSuccessfulResponse.setAuthenticated(true);
-        mockAuthenticatedFailedResponse = new TestingAuthenticationToken("exampleUsername", "examplePassword");
-        mockAuthenticatedFailedResponse.setAuthenticated(false);
-        mockAuthenticationRequest = new UsernamePasswordAuthenticationToken("exampleUsername", "examplePassword");
+        mockAuthenticatedSuccessfulResponse = UsernamePasswordAuthenticationToken.authenticated("exampleUsername2", "examplePassword2", null);
+        mockAuthenticatedFailedResponse = UsernamePasswordAuthenticationToken.unauthenticated("exampleUsername", "examplePassword");
+        mockAuthenticationRequest = UsernamePasswordAuthenticationToken.unauthenticated("exampleUsername", "examplePassword");
     }
 
     @AfterEach
@@ -68,7 +61,6 @@ class PersonControllerTest {
 
     @Test
     void testIfUserReturnedWhenLoginCorrect() throws LoginFailedException, LoggerException, UserNotFoundException {
-
         when(authenticationManager.authenticate(any(UsernamePasswordAuthenticationToken.class))).thenReturn(mockAuthenticatedSuccessfulResponse);
         when(personService.fetchLoggedInPersonByUsername(mockLoginRequestDTO.getUsername())).thenReturn(mockLoggedInPersonDTO);
         LoggedInPersonDTO returnedLoggedInPersonDTO = personController.login(mockLoginRequestDTO, session);

--- a/src/test/java/kth/iv1201/gohire/controller/PersonControllerTest.java
+++ b/src/test/java/kth/iv1201/gohire/controller/PersonControllerTest.java
@@ -6,7 +6,7 @@ import kth.iv1201.gohire.DTO.LoggedInPersonDTO;
 import kth.iv1201.gohire.DTO.LoginRequestDTO;
 import kth.iv1201.gohire.controller.util.LoggerException;
 import kth.iv1201.gohire.service.PersonService;
-import kth.iv1201.gohire.service.exception.LoginFailedException;
+import kth.iv1201.gohire.controller.exception.LoginFailedException;
 import kth.iv1201.gohire.service.exception.UserCreationFailedException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;

--- a/src/test/java/kth/iv1201/gohire/controller/PersonControllerTest.java
+++ b/src/test/java/kth/iv1201/gohire/controller/PersonControllerTest.java
@@ -1,5 +1,6 @@
 package kth.iv1201.gohire.controller;
 
+import jakarta.servlet.http.HttpSession;
 import kth.iv1201.gohire.DTO.CreateApplicantRequestDTO;
 import kth.iv1201.gohire.DTO.LoggedInPersonDTO;
 import kth.iv1201.gohire.DTO.LoginRequestDTO;
@@ -23,6 +24,8 @@ class PersonControllerTest {
 
     @Mock
     PersonService personService;
+    @Mock
+    HttpSession session;
     @InjectMocks
     PersonController personController;
     LoginRequestDTO mockLoginRequestDTO;
@@ -47,7 +50,7 @@ class PersonControllerTest {
     @Test
     void testIfUserReturnedWhenLoginCorrect() throws LoginFailedException, MethodArgumentNotValidException {
         when(personService.login(mockLoginRequestDTO)).thenReturn(mockLoggedInPersonDTO);
-        LoggedInPersonDTO returnedLoggedInPersonDTO = personController.login(mockLoginRequestDTO);
+        LoggedInPersonDTO returnedLoggedInPersonDTO = personController.login(mockLoginRequestDTO, session);
         assertEquals(mockLoggedInPersonDTO, returnedLoggedInPersonDTO,
                 "Returned LoggedInPersonDTO from PersonController does not equal returned" +
                         "LoggedInPersonDTO from PersonService.");
@@ -56,7 +59,7 @@ class PersonControllerTest {
     @Test
     void testIfLoginFailedExceptionIsThrownWhenCredentialsPresentButIncorrect() throws LoginFailedException {
         when(personService.login(mockLoginRequestDTO)).thenThrow(new LoginFailedException("Login Failed"));
-        assertThrowsExactly(LoginFailedException.class, () -> personController.login(mockLoginRequestDTO),
+        assertThrowsExactly(LoginFailedException.class, () -> personController.login(mockLoginRequestDTO, session),
                 "No LoginFailedException was thrown when credentials were incorrect.");
     }
 

--- a/src/test/java/kth/iv1201/gohire/controller/PersonControllerTest.java
+++ b/src/test/java/kth/iv1201/gohire/controller/PersonControllerTest.java
@@ -61,8 +61,10 @@ class PersonControllerTest {
 
     @Test
     void testIfUserReturnedWhenLoginCorrect() throws LoginFailedException, LoggerException, UserNotFoundException {
-        when(authenticationManager.authenticate(any(UsernamePasswordAuthenticationToken.class))).thenReturn(mockAuthenticatedSuccessfulResponse);
-        when(personService.fetchLoggedInPersonByUsername(mockLoginRequestDTO.getUsername())).thenReturn(mockLoggedInPersonDTO);
+        when(authenticationManager.authenticate(any(UsernamePasswordAuthenticationToken.class)))
+                .thenReturn(mockAuthenticatedSuccessfulResponse);
+        when(personService.fetchLoggedInPersonByUsername(mockLoginRequestDTO.getUsername()))
+                .thenReturn(mockLoggedInPersonDTO);
         LoggedInPersonDTO returnedLoggedInPersonDTO = personController.login(mockLoginRequestDTO, session);
         assertEquals(mockLoggedInPersonDTO, returnedLoggedInPersonDTO,
                 "Returned LoggedInPersonDTO from PersonController does not equal returned" +
@@ -70,8 +72,9 @@ class PersonControllerTest {
     }
 
     @Test
-    void testIfLoginFailedExceptionIsThrownWhenCredentialsPresentButIncorrect() throws LoginFailedException, UserNotFoundException {
-        when(personService.fetchLoggedInPersonByUsername(mockLoginRequestDTO.getUsername())).thenThrow(new LoginFailedException("Login Failed"));
+    void testIfLoginFailedExceptionIsThrownWhenCredentialsPresentButIncorrect() {
+        when(authenticationManager.authenticate(any(UsernamePasswordAuthenticationToken.class)))
+                .thenReturn(mockAuthenticatedFailedResponse);
         assertThrowsExactly(LoginFailedException.class, () -> personController.login(mockLoginRequestDTO, session),
                 "No LoginFailedException was thrown when credentials were incorrect.");
     }

--- a/src/test/java/kth/iv1201/gohire/service/PersonServiceTest.java
+++ b/src/test/java/kth/iv1201/gohire/service/PersonServiceTest.java
@@ -52,7 +52,7 @@ public class PersonServiceTest {
         roleEntity = null;
     }
 
-    @Test
+    /*@Test
     public void testIfLoginFailedExceptionIsThrownIfGivenWrongUsernameAndPassword() {
         LoginRequestDTO loginRequest = new LoginRequestDTO("esCod", "whatever");
         when(personRepository.findByUsernameAndPassword(loginRequest.getUsername(), loginRequest.getPassword())).thenReturn(null);
@@ -133,5 +133,5 @@ public class PersonServiceTest {
             fail("The user creation failed even though valid arguments were sent");
         }
     }
-
+    */
 }

--- a/src/test/java/kth/iv1201/gohire/service/PersonServiceTest.java
+++ b/src/test/java/kth/iv1201/gohire/service/PersonServiceTest.java
@@ -7,7 +7,7 @@ import kth.iv1201.gohire.entity.PersonEntity;
 import kth.iv1201.gohire.entity.RoleEntity;
 import kth.iv1201.gohire.repository.PersonRepository;
 import kth.iv1201.gohire.repository.RoleRepository;
-import kth.iv1201.gohire.service.exception.LoginFailedException;
+import kth.iv1201.gohire.controller.exception.LoginFailedException;
 import kth.iv1201.gohire.service.exception.UserCreationFailedException;
 import org.junit.jupiter.api.*;
 import static org.junit.jupiter.api.Assertions.*;

--- a/src/test/java/kth/iv1201/gohire/service/PersonServiceTest.java
+++ b/src/test/java/kth/iv1201/gohire/service/PersonServiceTest.java
@@ -9,6 +9,7 @@ import kth.iv1201.gohire.repository.PersonRepository;
 import kth.iv1201.gohire.repository.RoleRepository;
 import kth.iv1201.gohire.controller.exception.LoginFailedException;
 import kth.iv1201.gohire.service.exception.UserCreationFailedException;
+import kth.iv1201.gohire.service.exception.UserNotFoundException;
 import org.junit.jupiter.api.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -52,26 +53,20 @@ public class PersonServiceTest {
         roleEntity = null;
     }
 
-    /*@Test
-    public void testIfLoginFailedExceptionIsThrownIfGivenWrongUsernameAndPassword() {
-        LoginRequestDTO loginRequest = new LoginRequestDTO("esCod", "whatever");
-        when(personRepository.findByUsernameAndPassword(loginRequest.getUsername(), loginRequest.getPassword())).thenReturn(null);
-        try {
-            personService.login(loginRequest);
-            fail("The function did not return an expected exception.");
-        } catch (LoginFailedException exception) {
-            assertEquals(exception.getClass(), LoginFailedException.class);
-        }
+    @Test
+    public void testIfUserNotFoundExceptionIsThrownIfGivenNonExistingUsername() {
+        when(personRepository.findByUsername("esCod")).thenReturn(null);
+        assertThrowsExactly(UserNotFoundException.class, () -> personService.fetchLoggedInPersonByUsername("esCod"),
+                "The function did not return an expected exception.");
     }
 
     @Test
     public void testIfMethodReturnsWorkingLoggedInPersonDTO() {
-        LoginRequestDTO loginRequest = new LoginRequestDTO(fakePersonEntity.getUsername(), fakePersonEntity.getPassword());
-        when(personRepository.findByUsernameAndPassword(loginRequest.getUsername(), loginRequest.getPassword())).thenReturn(fakePersonEntity);
+        when(personRepository.findByUsername(fakePersonEntity.getUsername())).thenReturn(fakePersonEntity);
         try {
-            LoggedInPersonDTO loggedInUser = personService.login(loginRequest);
+            LoggedInPersonDTO loggedInUser = personService.fetchLoggedInPersonByUsername(fakePersonEntity.getUsername());
             assertEquals(fakePersonEntity.getUsername(), loggedInUser.getUsername());
-        } catch (LoginFailedException e) {
+        } catch (UserNotFoundException e) {
             fail("The function failed to fetch the correct data\n");
             e.printStackTrace();
         }
@@ -133,5 +128,5 @@ public class PersonServiceTest {
             fail("The user creation failed even though valid arguments were sent");
         }
     }
-    */
+
 }


### PR DESCRIPTION
Två nya klasser:
- `SecurityConfiguration`: inställningar för Spring Security, innehåller `SecurityFilterChain` som bestämmer vilka endpoints som är öppna för alla och vilka som behöver authorization. `SecurityFilterChain` kan konfigureras med mer säkerhetsfilter. `SecurityConfiguration` definierar också en `AuthenticationManager`, som autentiserar användare.
- `SpringDataJpaUserDetailsService`: Används av `AuthenticationManager` så den vet hur den ska hämta användare.

Utöver det använder man annotationer på Controller-metoder som specificerar vem som ska ha tillgång till den.

![Spring Security-2](https://github.com/kaytaffer/Go-Hire/assets/90849312/51b25d85-a680-431f-b60f-6ece3e3b2b96)

