### PR TITLE
Password encoding

### DIFF
--- a/src/main/java/kth/iv1201/gohire/config/SecurityConfiguration.java
+++ b/src/main/java/kth/iv1201/gohire/config/SecurityConfiguration.java
@@ -9,6 +9,8 @@ import org.springframework.security.config.annotation.method.configuration.Enabl
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
@@ -60,19 +62,25 @@ public class SecurityConfiguration {
 
         return http.build();
     }
+    /**
+     * Creates a configured <code>PasswordEncoder</code> that uses the BCrypt hashing algorithm.
+     * @return the configured <code>BCryptPasswordEncoder</code>
+     */
+    @Bean
+    public PasswordEncoder passwordEncoder(){return new BCryptPasswordEncoder();}
 
     /**
      * Creates an <code>AuthenticationManager</code> which manages the authentication of a user
      * @param userDetailsService <code>UserDetailsService</code> for specifying how to access users
+     * @param passwordEncoder the <code>PasswordEncoder</code> implementation to use for encoding passwords
      * @return the <code>AuthenticationManager</code>
      */
     @Bean
-    public AuthenticationManager authenticationManager(UserDetailsService userDetailsService) {
+    public AuthenticationManager authenticationManager(UserDetailsService userDetailsService, PasswordEncoder passwordEncoder) {
         DaoAuthenticationProvider authenticationProvider = new DaoAuthenticationProvider();
         authenticationProvider.setUserDetailsService(userDetailsService);
-
+        authenticationProvider.setPasswordEncoder(passwordEncoder);
         return new ProviderManager(authenticationProvider);
     }
-
 
 }

--- a/src/main/java/kth/iv1201/gohire/service/PersonService.java
+++ b/src/main/java/kth/iv1201/gohire/service/PersonService.java
@@ -12,6 +12,7 @@ import kth.iv1201.gohire.repository.PersonRepository;
 import kth.iv1201.gohire.service.exception.UserCreationFailedException;
 import kth.iv1201.gohire.service.exception.UserNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -31,18 +32,21 @@ public class PersonService {
     private final PersonRepository personRepository;
     private final RoleRepository roleRepository;
     private final ApplicationStatusRepository applicationStatusRepository;
+    private final PasswordEncoder passwordEncoder;
 
     /**
     * Creates an instance of the <code>PersonService</code>.
     * @param personRepository The <code>PersonRepository</code> to use.
     * @param roleRepository The <code>RoleRepository</code> to use.
+     * @param passwordEncoder the <code>PasswordEncoder</code> implementation to use for encoding passwords
     */
     @Autowired
     public PersonService(PersonRepository personRepository, RoleRepository roleRepository,
-                         ApplicationStatusRepository applicationStatusRepository) {
+                         ApplicationStatusRepository applicationStatusRepository,PasswordEncoder passwordEncoder) {
         this.personRepository = personRepository;
         this.roleRepository = roleRepository;
         this.applicationStatusRepository = applicationStatusRepository;
+        this.passwordEncoder = passwordEncoder;
     }
 
     /**
@@ -74,13 +78,16 @@ public class PersonService {
         RoleEntity roleEntity = roleRepository.findRoleById(APPLICANTROLEID);
         ApplicationStatusEntity applicationStatusEntity = applicationStatusRepository.findById(APPLICATIONSTATUSUNHANDLED);
 
+        // Encode raw password for secure storage.
+        String encodedPassword = passwordEncoder.encode(createUserRequestDTO.getPassword());
+
         personEntity.setRole(roleEntity);
         personEntity.setName(createUserRequestDTO.getFirstName());
         personEntity.setSurname(createUserRequestDTO.getLastName());
         personEntity.setEmail(createUserRequestDTO.getEmail());
         personEntity.setPersonNumber(createUserRequestDTO.getPersonNumber());
         personEntity.setUsername(createUserRequestDTO.getUsername());
-        personEntity.setPassword(createUserRequestDTO.getPassword());
+        personEntity.setPassword(encodedPassword);
         personEntity.setApplicationStatus(applicationStatusEntity);
         personEntity = personRepository.save(personEntity);
         return new LoggedInPersonDTO(personEntity.getId(), personEntity.getUsername(), personEntity.getRole().getName());

--- a/src/main/java/kth/iv1201/gohire/service/SpringDataJpaUserDetailsService.java
+++ b/src/main/java/kth/iv1201/gohire/service/SpringDataJpaUserDetailsService.java
@@ -41,8 +41,7 @@ public class SpringDataJpaUserDetailsService implements UserDetailsService {
         if (person == null) {
             throw new UsernameNotFoundException("User not found");
         }
-        return User.withDefaultPasswordEncoder()
-                .username(person.getUsername())
+        return User.withUsername(person.getUsername())
                 .password(person.getPassword())
                 .roles(person.getRole().getName())
                 .build();

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,8 @@
+# PostgreSQL database setup
 spring.profiles.active=local
 spring.datasource.driver-class-name=org.postgresql.Driver
 spring.jpa.open-in-view=false
+
+# Logging level for Spring Security, enables detailed logs for debugging purpose
+logging.level.org.springframework.security=DEBUG
+

--- a/src/test/java/kth/iv1201/gohire/service/PersonServiceTest.java
+++ b/src/test/java/kth/iv1201/gohire/service/PersonServiceTest.java
@@ -48,7 +48,7 @@ public class PersonServiceTest {
         Mockito.reset(personRepository);
         Mockito.reset(roleRepository);
         Mockito.reset(applicationStatusRepository);
-        this.personService = new PersonService(personRepository, roleRepository, applicationStatusRepository);
+        this.personService = new PersonService(personRepository, roleRepository, applicationStatusRepository,passwordEncoder);
         this.fakeRecruiterEntity = new PersonEntity();
         fakeRecruiterEntity.setUsername("aValidUsername");
         fakeRecruiterEntity.setPassword("aValidPassword");

--- a/src/test/java/kth/iv1201/gohire/service/PersonServiceTest.java
+++ b/src/test/java/kth/iv1201/gohire/service/PersonServiceTest.java
@@ -19,6 +19,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 import java.util.LinkedList;
 import java.util.List;
@@ -31,6 +32,9 @@ public class PersonServiceTest {
     RoleRepository roleRepository;
     @Mock
     ApplicationStatusRepository applicationStatusRepository;
+    @Mock
+    PasswordEncoder passwordEncoder;
+
     @InjectMocks
     PersonService personService;
     PersonEntity fakePersonEntity;
@@ -38,12 +42,14 @@ public class PersonServiceTest {
     ApplicationStatusEntity fakeApplicationStatus;
     PersonEntity fakeApplicantPerson;
 
+
     @BeforeEach
     public void setUp() {
         Mockito.reset(personRepository);
         Mockito.reset(roleRepository);
         Mockito.reset(applicationStatusRepository);
-        this.personService = new PersonService(personRepository, roleRepository, applicationStatusRepository);
+        Mockito.reset(passwordEncoder);
+        this.personService = new PersonService(personRepository, roleRepository, applicationStatusRepository, passwordEncoder);
         this.fakePersonEntity = new PersonEntity();
         fakePersonEntity.setUsername("aValidUsername");
         fakePersonEntity.setPassword("aValidPassword");
@@ -67,6 +73,8 @@ public class PersonServiceTest {
         personRepository.delete(fakePersonEntity);
         fakePersonEntity = null;
         roleEntity = null;
+        passwordEncoder = null;
+
     }
 
     @Test


### PR DESCRIPTION
Efter denna kod är tillagd kommer man inte kunna logga in med befintliga användare förrän de befintliga lösenorden i databasen är krypterade. Separat metod för engångskryptering(se discord)

- Testad i Chrome och Safari 
- Uppdaterat `PersonServiceTest` med att ta emot en `PasswordEncoder`. Men har ej skrivit nya tester för encoding-funktionaliteten. 