### PR TITLE
Logout även vid expired session

### DIFF
--- a/src/main/js/app.js
+++ b/src/main/js/app.js
@@ -9,6 +9,7 @@ import {ContainerView} from "./view/containerView";
 import {logout} from "./presenter/api/apiCallHandler";
 import {i182} from "./presenter/i18n/i18nConfig";
 import {TopBar} from "./presenter/topBar";
+import {PAGE_DOES_NOT_EXIST} from "./presenter/api/errorMessages";
 
 /**
  * Root component for the application.
@@ -54,11 +55,16 @@ function App() {
     }, [])
 
     function onLogout() {
-        logout().then(() => {
+        function logoutInBrowser() {
             localStorage.clear()
             navigate('/login')
             setUser(null)
-        });
+        }
+
+        logout().then(logoutInBrowser).catch(error => {
+            if(error.message === PAGE_DOES_NOT_EXIST.errorType)
+                logoutInBrowser()
+        })
     }
 
     return (


### PR DESCRIPTION
När browsern tror att man är inloggad, men servern inte tycker att man är det, och man trycker på logout-knappen blir man utloggad i browsern

För att testa kan man använda `localStorage.setItem('user', JSON.stringify({"id":3,"username":"DanteMason","role":"recruiter"}))` i konsolen, refresha sidan och trycka på logout, så borde man loggas ut och komma till login-sidan

Testat i Safari och Chrome